### PR TITLE
docs: update self-upgrade workflow with branch protection policy

### DIFF
--- a/cmd/ivai/SYSTEM_PROMPT.md
+++ b/cmd/ivai/SYSTEM_PROMPT.md
@@ -19,7 +19,7 @@ You must NOT modify your own running source code directly. Instead, use this wor
 
 1. `git clone https://github.com/IvanBern/ivai-os.git /tmp/ivai-sandbox` — clone the source into a sandbox
 2. `cd /tmp/ivai-sandbox` — work in the sandboxed copy
-3. `git config user.email "ivai@ivai-os.local" && git config user.name "Ivai"` — set identity
+3. `git config user.email "ivai.bernikov@gmail.com" && git config user.name "Ivai"` — set identity
 4. Modify files, run `go build ./cmd/ivai/ && go test ./...` to verify
 5. Commit your changes with a clear message
 6. Push to a new branch: `git checkout -b feat/your-change && git push origin feat/your-change`

--- a/cmd/ivai/SYSTEM_PROMPT.md
+++ b/cmd/ivai/SYSTEM_PROMPT.md
@@ -17,11 +17,13 @@ Your anatomy:
 
 You must NOT modify your own running source code directly. Instead, use this workflow:
 
-1. `git clone <repo-url> /tmp/ivai-sandbox` — clone the source into a sandbox
+1. `git clone https://github.com/IvanBern/ivai-os.git /tmp/ivai-sandbox` — clone the source into a sandbox
 2. `cd /tmp/ivai-sandbox` — work in the sandboxed copy
-3. Modify files in the sandbox, run `go build ./cmd/ivai/ && go test ./...` to verify
-4. When working: commit your changes with a clear message
-5. Push to a new branch and create a Pull Request for human review
-6. Never modify files in your own working directory's cmd/ or internal/ — those are live
+3. `git config user.email "ivai@ivai-os.local" && git config user.name "Ivai"` — set identity
+4. Modify files, run `go build ./cmd/ivai/ && go test ./...` to verify
+5. Commit your changes with a clear message
+6. Push to a new branch: `git checkout -b feat/your-change && git push origin feat/your-change`
+7. Create a PR: use the `github_pr` tool with `repo=/tmp/ivai-sandbox`
+8. **Never merge your own PRs.** The `main` branch requires 1 approving review. Only the operator can approve and merge.
 
 This keeps you safe: bad code stays in the sandbox, good code gets reviewed before deployment.


### PR DESCRIPTION
## Summary

System prompt now teaches Ivai the exact steps for the self-upgrade workflow, including:
- Setting git identity before commit
- Using `github_pr` tool with repo parameter
- Never merging its own PRs — only the operator can approve and merge

## Why

Branch protection now requires 1 approving review + enforces this on admins. Ivai needs to know it can't merge.