### PR TITLE
feat: add semantic memory with embeddings and RAG pipeline

### DIFF
--- a/cmd/ivai/main.go
+++ b/cmd/ivai/main.go
@@ -379,7 +379,7 @@ func processTask(ctx context.Context, in TaskInput, progressChan chan<- Progress
 	state.emit(ProgressEvent{Type: "task_start", Message: "Task started", Data: map[string]string{"model": model, "instruction": instruction}})
 
 	startTime := time.Now()
-	payload := buildPayload(in.DBStore)
+	payload := buildPayload(in.DBStore, in.Gateway)
 	result := runReasoningLoop(ctx, payload, state)
 	duration := time.Since(startTime).Milliseconds()
 
@@ -397,6 +397,15 @@ func processTask(ctx context.Context, in TaskInput, progressChan chan<- Progress
 		ErrorMsg:    errMsg,
 		DurationMs:  duration,
 	})
+
+	// Auto-embed the instruction for future semantic recall (fire and forget)
+	go func() {
+		emb, err := in.Gateway.Embed(context.Background(), instruction)
+		if err != nil {
+			return
+		}
+		in.DBStore.SaveEmbedding("instruction", instruction, emb)
+	}()
 
 	// Close progress channel when done (if it exists) to signal completion to SSE handler.
 	if progressChan != nil {
@@ -489,15 +498,18 @@ func buildTools() []llm.Tool {
 	}
 }
 
-func buildPayload(dbStore *memory.Store) []llm.Message {
+func buildPayload(dbStore *memory.Store, gateway *llm.Gateway) []llm.Message {
 	history, _ := dbStore.GetRecentMessages(10)
 	homeDir, _ := os.UserHomeDir()
 	cwd, _ := os.Getwd()
-	systemPrompt := fmt.Sprintf(systemPromptTemplate, homeDir, cwd)
 
 	payload := []llm.Message{
-		{Role: "system", Content: systemPrompt},
+		{Role: "system", Content: fmt.Sprintf(systemPromptTemplate, homeDir, cwd)},
 	}
+
+	// RAG: inject semantically similar past context
+	payload = injectRAGContext(payload, dbStore, gateway, history)
+
 	for _, msg := range history {
 		payload = append(payload, llm.Message{
 			Role:             msg.Role,
@@ -506,6 +518,26 @@ func buildPayload(dbStore *memory.Store) []llm.Message {
 		})
 	}
 	return payload
+}
+
+func injectRAGContext(payload []llm.Message, dbStore *memory.Store, gateway *llm.Gateway, history []memory.Message) []llm.Message {
+	if len(history) == 0 {
+		return payload
+	}
+	latestMsg := history[len(history)-1].Content
+	emb, err := gateway.Embed(context.Background(), latestMsg)
+	if err != nil {
+		return payload
+	}
+	similar, err := dbStore.SearchSimilar(emb, 3)
+	if err != nil || len(similar) == 0 {
+		return payload
+	}
+	ragCtx := "## Relevant Past Context (from semantic memory)\n"
+	for i, s := range similar {
+		ragCtx += fmt.Sprintf("%d. [%.0f%% match] %s\n", i+1, s.Similarity*100, s.Content)
+	}
+	return append(payload, llm.Message{Role: "system", Content: ragCtx})
 }
 
 func runReasoningLoop(ctx context.Context, payload []llm.Message, s *taskState) string {

--- a/internal/llm/gateway.go
+++ b/internal/llm/gateway.go
@@ -142,9 +142,10 @@ type Gateway struct {
 	HTTPClient   *http.Client
 
 	// Base URLs for testing
-	DeepSeekURL  string
-	AnthropicURL string
-	GeminiURL    string
+	DeepSeekURL     string
+	AnthropicURL    string
+	GeminiURL       string
+	DeepSeekEmbedURL string
 }
 
 func NewGateway(deepSeekKey, anthropicKey, geminiKey string) *Gateway {
@@ -155,10 +156,49 @@ func NewGateway(deepSeekKey, anthropicKey, geminiKey string) *Gateway {
 		HTTPClient: &http.Client{
 			Timeout: 120 * time.Second,
 		},
-		DeepSeekURL:  "https://api.deepseek.com/chat/completions",
-		AnthropicURL: "https://api.anthropic.com/v1/messages",
-		GeminiURL:    "https://generativelanguage.googleapis.com/v1beta/models",
+		DeepSeekURL:      "https://api.deepseek.com/chat/completions",
+		AnthropicURL:     "https://api.anthropic.com/v1/messages",
+		GeminiURL:        "https://generativelanguage.googleapis.com/v1beta/models",
+		DeepSeekEmbedURL: "https://api.deepseek.com/v1/embeddings",
 	}
+}
+
+// --- Embedding API ---
+
+type EmbeddingRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+}
+
+type EmbeddingResponse struct {
+	Data []struct {
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
+}
+
+// Embed generates an embedding vector for the given text using DeepSeek.
+func (g *Gateway) Embed(ctx context.Context, text string) ([]float64, error) {
+	reqBody := EmbeddingRequest{
+		Model: "deepseek-chat",
+		Input: text,
+	}
+
+	var embResp EmbeddingResponse
+	if err := g.doProviderRequest(ctx, providerCall{
+		url:      g.DeepSeekEmbedURL,
+		body:     reqBody,
+		headers:  map[string]string{"Content-Type": "application/json", "Authorization": "Bearer " + g.DeepSeekKey},
+		provider: "DeepSeek",
+		target:   &embResp,
+	}); err != nil {
+		return nil, err
+	}
+
+	if len(embResp.Data) == 0 {
+		return nil, fmt.Errorf("DeepSeek embeddings returned no data")
+	}
+
+	return embResp.Data[0].Embedding, nil
 }
 
 func (g *Gateway) Chat(ctx context.Context, messages []Message, tools []Tool, model string) (Message, error) {

--- a/internal/memory/db.go
+++ b/internal/memory/db.go
@@ -2,7 +2,9 @@ package memory
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
+	"math"
 
 	_ "modernc.org/sqlite" // Pure Go SQLite driver
 )
@@ -45,6 +47,14 @@ func NewStore(dbPath string) (*Store, error) {
 		response TEXT DEFAULT '',
 		error_msg TEXT DEFAULT '',
 		duration_ms INTEGER NOT NULL DEFAULT 0,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE TABLE IF NOT EXISTS embeddings (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		source TEXT NOT NULL DEFAULT '',
+		content TEXT NOT NULL,
+		embedding BLOB NOT NULL,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	);`
 
@@ -156,4 +166,105 @@ func (s *Store) GetTaskResults(limit int) ([]TaskResult, error) {
 		results = append(results, tr)
 	}
 	return results, nil
+}
+
+// SaveEmbedding stores a text embedding for semantic search.
+func (s *Store) SaveEmbedding(source, content string, embedding []float64) error {
+	data, err := json.Marshal(embedding)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec("INSERT INTO embeddings (source, content, embedding) VALUES (?, ?, ?)", source, content, data)
+	return err
+}
+
+// EmbeddingResult holds a search result with similarity score.
+type EmbeddingResult struct {
+	Source     string  `json:"source"`
+	Content    string  `json:"content"`
+	Similarity float64 `json:"similarity"`
+}
+
+// SearchSimilar finds the most semantically similar stored embeddings.
+func (s *Store) SearchSimilar(queryEmbedding []float64, limit int) ([]EmbeddingResult, error) {
+	candidates, err := s.loadRecentEmbeddings(200)
+	if err != nil {
+		return nil, err
+	}
+	return scoreAndRank(queryEmbedding, candidates, limit), nil
+}
+
+func (s *Store) loadRecentEmbeddings(limit int) ([]candidate, error) {
+	rows, err := s.db.Query("SELECT source, content, embedding FROM embeddings ORDER BY id DESC LIMIT ?", limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		var embJSON []byte
+		if err := rows.Scan(&c.source, &c.content, &embJSON); err != nil {
+			continue
+		}
+		json.Unmarshal(embJSON, &c.embedding)
+		candidates = append(candidates, c)
+	}
+	return candidates, nil
+}
+
+type candidate struct {
+	source    string
+	content   string
+	embedding []float64
+}
+
+type scoredResult struct {
+	source     string
+	content    string
+	similarity float64
+}
+
+func scoreAndRank(queryEmb []float64, candidates []candidate, limit int) []EmbeddingResult {
+	var scored []scoredResult
+	for _, c := range candidates {
+		sim := cosineSimilarity(queryEmb, c.embedding)
+		if sim > 0.3 {
+			scored = append(scored, scoredResult{c.source, c.content, sim})
+		}
+	}
+	sortScoredBySimilarity(scored)
+	if limit > 0 && len(scored) > limit {
+		scored = scored[:limit]
+	}
+	results := make([]EmbeddingResult, len(scored))
+	for i, s := range scored {
+		results[i] = EmbeddingResult{Source: s.source, Content: s.content, Similarity: s.similarity}
+	}
+	return results
+}
+
+func sortScoredBySimilarity(scored []scoredResult) {
+	for i := 1; i < len(scored); i++ {
+		for j := i; j > 0 && scored[j].similarity > scored[j-1].similarity; j-- {
+			scored[j], scored[j-1] = scored[j-1], scored[j]
+		}
+	}
+}
+
+func cosineSimilarity(a, b []float64) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		dot += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
 }


### PR DESCRIPTION
## Summary

- **LLM gateway**: `Embed()` method using DeepSeek embeddings API
- **Memory store**: `embeddings` table, `SaveEmbedding`, `SearchSimilar` with cosine similarity
- **Auto-embed**: every task instruction is embedded after completion
- **RAG injection**: `buildPayload` searches for semantically similar past context and injects it before the LLM call
- Threshold: similarity > 0.3, top 3 results

## Why

Phase 6.2 — gives Ivai semantic memory. Instead of just the last 10 chronological messages, Ivai can now find relevant past context by meaning, enabling pattern recognition across sessions.