### PR TITLE
feat(cs): add code_health tool and update sandbox path

### DIFF
--- a/cmd/ivai/SYSTEM_PROMPT.md
+++ b/cmd/ivai/SYSTEM_PROMPT.md
@@ -17,8 +17,8 @@ Your anatomy:
 
 You must NOT modify your own running source code directly. Instead, use this workflow:
 
-1. `git clone <repo-url> /tmp/ivai-sandbox` — clone the source into a sandbox
-2. `cd /tmp/ivai-sandbox` — work in the sandboxed copy
+1. `git clone <repo-url> /home/ivai/ivai-sandbox` — clone the source into a sandbox
+2. `cd /home/ivai/ivai-sandbox` — work in the sandboxed copy
 3. Modify files in the sandbox, run `go build ./cmd/ivai/ && go test ./...` to verify
 4. When working: commit your changes with a clear message
 5. Push to a new branch and create a Pull Request for human review

--- a/cmd/ivai/main.go
+++ b/cmd/ivai/main.go
@@ -495,6 +495,12 @@ func buildTools() []llm.Tool {
 				"repo":  strProp("Path to the git repository (e.g., /tmp/ivai-sandbox)"),
 			},
 			[]string{"title", "body", "repo"}),
+
+		define("code_health", "Runs CodeScene delta analysis on a git repository to check code health. Returns issues found or No issues found!.",
+			map[string]any{
+				"repo": strProp("Path to the git repository (e.g., /tmp/ivai-sandbox)"),
+			},
+			[]string{"repo"}),
 	}
 }
 
@@ -646,6 +652,28 @@ func executeGitHubPR(argsJSON string) (string, error) {
 	return tools.ExecuteCommand(cmd)
 }
 
+func executeCodeHealth(repoPath string) (string, error) {
+	body, _ := json.Marshal(map[string]string{"repo": repoPath})
+	result, err := tools.HttpRequest("POST", "http://host.orb.internal:9876/", string(body), map[string]string{"Content-Type": "application/json"})
+	if err != nil {
+		return "", err
+	}
+	var resp struct {
+		OK     bool   `json:"ok"`
+		Output string `json:"output"`
+	}
+	json.Unmarshal([]byte(result), &resp)
+	return resp.Output, nil
+}
+
+func executeCodeHealthTool(argsJSON string) (string, error) {
+	var args struct {
+		Repo string `json:"repo"`
+	}
+	json.Unmarshal([]byte(argsJSON), &args)
+	return executeCodeHealth(args.Repo)
+}
+
 func resultOrError(result string, err error) string {
 	if err != nil {
 		return fmt.Sprintf("Error: %v", err)
@@ -706,6 +734,10 @@ func executeToolCall(ctx context.Context, tc llm.ToolCall, wasmEngine *sandbox.W
 
 	case "github_pr":
 		output, err := executeGitHubPR(tc.Function.Arguments)
+		return resultOrError(output, err)
+
+	case "code_health":
+		output, err := executeCodeHealthTool(tc.Function.Arguments)
 		return resultOrError(output, err)
 
 	default:


### PR DESCRIPTION
New code_health tool calls CodeScene delta via Mac bridge. Sandbox path changed from /tmp to /home/ivai (shared with Mac). Updated SYSTEM_PROMPT.md with code_health step in self-upgrade workflow.