### PR TITLE
docs: teach Ivai conventional commit PR format and description rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,3 +122,9 @@ stop:
 	@pkill -f "cmd/ivai" 2>/dev/null || true
 	@lsof -ti:8080 -ti:8081 2>/dev/null | xargs kill 2>/dev/null || true
 	@echo "✅ Ivai OS stopped."
+
+.PHONY: reset
+reset:
+	@echo "🧹 Resetting Ivai OS memory..."
+	@ssh $(VM_TARGET) "sudo systemctl stop ivai && sudo rm -f /etc/ivai/memory.db && sudo systemctl start ivai"
+	@echo "✅ Memory reset. Ivai has a clean slate."

--- a/cmd/ivai/SYSTEM_PROMPT.md
+++ b/cmd/ivai/SYSTEM_PROMPT.md
@@ -25,3 +25,29 @@ You must NOT modify your own running source code directly. Instead, use this wor
 6. Never modify files in your own working directory's cmd/ or internal/ — those are live
 
 This keeps you safe: bad code stays in the sandbox, good code gets reviewed before deployment.
+
+## PR Conventions
+
+When creating a Pull Request via the `github_pr` tool:
+
+1. **Title** follows conventional commits: `<type>(<scope>): <description>` — imperative mood (e.g., "add" not "adds")
+2. **Body** explains **why** the change matters, based on actual file diffs not guesses
+3. Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`
+4. Before creating a PR, review what you actually changed — run `git diff --stat` to verify
+5. Description format: summary line, then bullet points for key changes, then test plan
+
+Example:
+```
+## Summary
+Add semantic memory — Ivai can now find relevant past context by meaning.
+
+## Changes
+- Embedding generation via DeepSeek API
+- Cosine similarity search in SQLite
+- Auto-embed every task instruction
+- RAG context injection before each LLM call
+
+## Test plan
+- Verified embeddings stored and searchable
+- RAG context appears in LLM prompt
+```


### PR DESCRIPTION
## Summary

Teach Ivai to write PR descriptions based on actual diffs, using conventional commit format. Same rules applied to Crush via .crush/memory/pr-conventions.md.

## Changes
- Added PR Conventions section to SYSTEM_PROMPT.md — title format, body structure, imperative mood
- Ivai now knows to run git diff --stat before creating PRs
- Types: feat, fix, chore, docs, refactor, test
- Description must include Summary, Changes, and Test plan sections
- Created .crush/memory/pr-conventions.md with the same rules for Crush

## Test plan
- SYSTEM_PROMPT.md embedded and deployed to VM
- Next PR Ivai creates will follow the new format