### PR TITLE
feat(sdlc): add GitHub Issue tools and templates (#1, #2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Something is broken
+title: "fix: "
+labels: bug
+assignees: ivaiber
+---
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Phase
+
+<!-- Which roadmap phase does this relate to? -->
+
+## Logs / Screenshots
+
+<!-- Paste relevant journald logs or dashboard screenshots -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: New capability or enhancement
+title: "feat: "
+labels: enhancement
+assignees: ivaiber
+---
+
+## Problem
+
+<!-- What problem does this solve? -->
+
+## Proposed Solution
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+
+## Phase
+
+<!-- Which roadmap phase? -->
+
+## Design Doc
+
+<!-- Link to docs/designs/ or docs/specs/ if applicable -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -239,3 +239,107 @@ Cross-cutting architectural patterns that span multiple phases:
 ## 🔭 Vision
 
 Long-term aspirational horizons live in [docs/VISION.md](docs/VISION.md). They are not committed to the roadmap but inform architectural decisions today.
+
+---
+
+## 🔧 Phase 13: SDLC Excellence (In Progress)
+
+**Spec:** (to create: `docs/specs/phase-13-sdlc.md`)
+**Depends on:** Phase 7 ✅ (self-evolution foundation), Phase 8 ✅ (observability)
+**Goal:** Full automated development lifecycle — Ivai manages its own work from issue to deploy.
+
+| # | Item | Status | Design | Verifier |
+|---|------|--------|--------|----------|
+| 13.1 | GitHub Issues API Tool (`create_issue`, `list_issues`, `label_issue`) | 🔴 | Ivai creates structured issues from roadmap items, self-assigns, labels by phase | `TestIssueCreation` |
+| 13.2 | Issue Templates (`.github/ISSUE_TEMPLATE/`) | 🔴 | bug.md, feature.md with acceptance criteria, phase linkage | Template renders on new issue |
+| 13.3 | Dashboard CI Badge | 🔴 | Web UI shows current pipeline status (green/red) via GitHub API | `TestCIBadge` |
+| 13.4 | ADR Directory (`docs/adr/`) | 🔴 | Architecture Decision Records: why sqlite-vec over chromem-go, why wazero, etc. Template + first 3 ADRs | `docs/adr/0001-*.md` exists |
+| 13.5 | Rollback (`make rollback`) | 🔴 | Keeps previous binary as `/usr/local/bin/ivai-os.prev`, rollback restores it + restarts | `make rollback` restores prev version |
+| 13.6 | Feature Flags | 🔴 | Env-var based: `IVAI_FEATURE_*=true/false`. New capabilities ship disabled, enabled after staging validation | `TestFeatureFlag` |
+| 13.7 | GitHub Wiki API Tool | 🔴 | Ivai writes capability docs to wiki after each merged PR | `TestWikiUpdate` |
+| 13.8 | Signed Commits (`git commit -S`) | 🔴 | GPG signing configured for Ivai's GitHub identity, verified by branch protection | `TestSignedCommit` |
+| 13.9 | Regression Test Suite | 🔴 | Tests for core reasoning loop, all 7 tool dispatches, buildPayload, SSE streaming | `TestRegressionSuite` |
+| 13.10 | Mermaid Diagrams in Specs | 🔴 | Architecture diagrams in docs/specs/ using mermaid.js blocks | `TestMermaidRender` |
+
+**Design docs referenced:** This phase (solution designs in section below)
+**Architecture impacted:** §2 Cognitive Engine, §5 Interfaces, §7 Web Dashboard
+**VISION link:** [Horizon I — Meta-Cognition](docs/VISION.md#horizon-i-meta-cognition--self-debugging)
+
+### Design Solutions
+
+#### 13.1 GitHub Issues API Tool
+
+Ivai gains `create_issue`, `list_issues`, `label_issue` tools via `gh issue` CLI.
+```
+create_issue(title, body, labels[], assignee?)
+list_issues(state, labels, limit)
+label_issue(number, labels[])
+```
+Creates issues from ROADMAP.md items. Labels map to phases: `phase-6`, `phase-13`, etc.
+Self-assigns to `ivaiber`.
+
+#### 13.2 Issue Templates
+
+Three templates with YAML frontmatter for GitHub's form builder:
+- `bug.md`: Steps to reproduce, expected vs actual, phase
+- `feature.md`: Problem, acceptance criteria, phase, design doc ref
+- `spec.md`: For spec documents — links to ROADMAP item, design decisions
+
+#### 13.3 Dashboard CI Badge
+
+New `Pipeline` tab in Web UI fetches GitHub Actions status via this repo's API:
+```
+GET https://api.github.com/repos/IvanBern/ivai-os/actions/runs?branch=main&per_page=1
+```
+Shows: last run status (✅/❌), timestamp, link to run. Auto-refreshes.
+
+#### 13.4 ADR Directory
+
+Template: `docs/adr/0001-template.md`
+First 3 ADRs: sqlite-vec choice, wazero over docker, embedded Go over microservices.
+
+#### 13.5 Rollback
+
+`make rollback`:
+1. Stops ivai service
+2. `mv /usr/local/bin/ivai-os.prev /usr/local/bin/ivai-os`
+3. Starts ivai service
+4. Keeps current binary as new `.prev` for next rollback
+
+#### 13.6 Feature Flags
+
+Minimal implementation — env var prefix `IVAI_FEATURE_`:
+```go
+func featureEnabled(name string) bool {
+    return os.Getenv("IVAI_FEATURE_"+strings.ToUpper(name)) == "true"
+}
+```
+First flag: `IVAI_FEATURE_RAG=true` — controls RAG context injection.
+
+#### 13.7 GitHub Wiki API Tool
+
+`update_wiki(page, content)` — writes/updates a wiki page via:
+```
+gh api repos/IvanBern/ivai-os/pages -f title="$page" -f content="$content"
+```
+Auto-runs after each merged PR. Documents capabilities, tools, architecture changes.
+
+#### 13.8 Signed Commits
+
+Ivai's VM identity gets a GPG key. Git config: `commit.gpgsign=true`.
+Branch protection requires signed commits.
+
+#### 13.9 Regression Test Suite
+
+`cmd/ivai/main_test.go` additions:
+- `TestAllToolDispatch` — all 7 tools execute without panic
+- `TestReasoningLoopCompletes` — simple task → SSE events → final response
+- `TestBuildPayloadRAG` — RAG context injected when embeddings exist
+- `TestSSEStreamFormat` — valid event: data: format
+
+#### 13.10 Mermaid Diagrams
+
+Add to `docs/specs/` and `ARCHITECTURE.md`:
+- System context diagram
+- Data flow: CLI/Web → HTTP → taskChan → reasoning loop → LLM → tools
+- State machine: Ivai task lifecycle (queued → thinking → tool_call → tool_result → complete/error)

--- a/cmd/ivai/main.go
+++ b/cmd/ivai/main.go
@@ -511,6 +511,23 @@ func buildTools() []llm.Tool {
 				"repo": strProp("Path to the git repository (e.g., /tmp/ivai-sandbox)"),
 			},
 			[]string{"repo"}),
+
+		define("create_issue", "Creates a GitHub Issue. Uses gh CLI. Provide title, body, labels (comma-separated), and optional assignee.",
+			map[string]any{
+				"title":    strProp("Issue title"),
+				"body":     strProp("Issue description"),
+				"labels":   strProp("Comma-separated labels (e.g., bug,phase-13)"),
+				"assignee": strProp("GitHub username to assign (optional)"),
+			},
+			[]string{"title", "body"}),
+
+		define("list_issues", "Lists GitHub Issues with optional filters.",
+			map[string]any{
+				"state":  strProp("open, closed, or all (default: open)"),
+				"labels": strProp("Comma-separated label filter (optional)"),
+				"limit":  strProp("Max issues to return (default: 10)"),
+			},
+			[]string{}),
 	}
 }
 
@@ -687,6 +704,44 @@ func executeCodeHealthTool(argsJSON string) (string, error) {
 	return executeCodeHealth(args.Repo)
 }
 
+func executeCreateIssue(argsJSON string) (string, error) {
+	var args struct {
+		Title    string `json:"title"`
+		Body     string `json:"body"`
+		Labels   string `json:"labels"`
+		Assignee string `json:"assignee"`
+	}
+	json.Unmarshal([]byte(argsJSON), &args)
+	cmd := fmt.Sprintf("gh issue create --repo IvanBern/ivai-os --title %q --body %q", args.Title, args.Body)
+	if args.Labels != "" {
+		cmd += fmt.Sprintf(" --label %q", args.Labels)
+	}
+	if args.Assignee != "" {
+		cmd += fmt.Sprintf(" --assignee %q", args.Assignee)
+	}
+	return tools.ExecuteCommand(cmd)
+}
+
+func executeListIssues(argsJSON string) (string, error) {
+	var args struct {
+		State  string `json:"state"`
+		Labels string `json:"labels"`
+		Limit  string `json:"limit"`
+	}
+	json.Unmarshal([]byte(argsJSON), &args)
+	if args.State == "" {
+		args.State = "open"
+	}
+	if args.Limit == "" {
+		args.Limit = "10"
+	}
+	cmd := fmt.Sprintf("gh issue list --repo IvanBern/ivai-os --state %s --limit %s --json title,state,labels,assignees", args.State, args.Limit)
+	if args.Labels != "" {
+		cmd += fmt.Sprintf(" --label %q", args.Labels)
+	}
+	return tools.ExecuteCommand(cmd)
+}
+
 func resultOrError(result string, err error) string {
 	if err != nil {
 		return fmt.Sprintf("Error: %v", err)
@@ -756,6 +811,14 @@ func executeToolCall(ctx context.Context, tc llm.ToolCall, wasmEngine *sandbox.W
 
 	case "code_health":
 		output, err := executeCodeHealthTool(tc.Function.Arguments)
+		return resultOrError(output, err)
+
+	case "create_issue":
+		output, err := executeCreateIssue(tc.Function.Arguments)
+		return resultOrError(output, err)
+
+	case "list_issues":
+		output, err := executeListIssues(tc.Function.Arguments)
 		return resultOrError(output, err)
 
 	default:


### PR DESCRIPTION
## Summary

Ivai can now create and list GitHub Issues. Issue templates added for bugs and features.

## Changes
- **create_issue tool**: title, body, labels, assignee — uses gh CLI with --repo flag
- **list_issues tool**: state, labels, limit filters — JSON output
- **Bug template**: steps to reproduce, expected/actual, phase, logs
- **Feature template**: problem, solution, acceptance criteria, phase, design doc ref
- **Phase 13 added** to ROADMAP.md with all 10 SDLC items and solution designs

## Test Results
```
ok  github.com/IvanBern/ivai-os/cmd/ivai
ok  github.com/IvanBern/ivai-os/cmd/ivaictl
ok  github.com/IvanBern/ivai-os/internal/llm
ok  github.com/IvanBern/ivai-os/internal/memory
ok  github.com/IvanBern/ivai-os/internal/sandbox
ok  github.com/IvanBern/ivai-os/internal/telemetry
ok  github.com/IvanBern/ivai-os/internal/tools
```

## Verification
- Ivai created issues #14 and #15 via create_issue tool
- Both successfully created and closed
