### PR TITLE
feat(sdlc): add ADR directory, rollback target, deploy backup (#3-5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ deploy: build build-cli-linux
 	@echo "🚀 Shipping binaries to Debian VM..."
 	scp $(BINARY_NAME) $(CLI_NAME)-linux $(VM_TARGET):~/
 	@echo "🔒 Securing binaries..."
-	ssh $(VM_TARGET) "sudo mv ~/$(BINARY_NAME) $(BIN_DEST) && sudo mv ~/$(CLI_NAME)-linux /usr/local/bin/$(CLI_NAME) && sudo chown ivai:ivai $(BIN_DEST) /usr/local/bin/$(CLI_NAME) && sudo chmod +x $(BIN_DEST) /usr/local/bin/$(CLI_NAME)"
+	ssh $(VM_TARGET) "sudo cp $(BIN_DEST) $(BIN_DEST).prev 2>/dev/null; sudo mv ~/$(BINARY_NAME) $(BIN_DEST) && sudo mv ~/$(CLI_NAME)-linux /usr/local/bin/$(CLI_NAME) && sudo chown ivai:ivai $(BIN_DEST) /usr/local/bin/$(CLI_NAME) && sudo chmod +x $(BIN_DEST) /usr/local/bin/$(CLI_NAME)"
 	@echo "✅ Deployment complete!"
 
 # 2.1 Deploy environment secrets
@@ -143,3 +143,8 @@ deploy-staging: build
 	@scp $(BINARY_NAME) ivai-os-linux@ai-server:~/
 	@ssh ivai-os-linux@ai-server "sudo mv ~/$(BINARY_NAME) /usr/local/bin/ivai-os-staging && sudo chmod +x /usr/local/bin/ivai-os-staging && sudo pkill -f ivai-os-staging 2>/dev/null; IVAI_PORT=8099 /usr/local/bin/ivai-os-staging &"
 	@echo "✅ Staging deployed on ai-server:8099"
+
+.PHONY: rollback
+rollback:
+	@echo "⏪ Rolling back Ivai OS..."
+	@ssh $(VM_TARGET) "sudo systemctl stop ivai && test -f /usr/local/bin/ivai-os.prev && sudo mv /usr/local/bin/ivai-os /usr/local/bin/ivai-os.bad && sudo mv /usr/local/bin/ivai-os.prev /usr/local/bin/ivai-os && sudo systemctl start ivai && echo '✅ Rolled back' || echo '❌ No previous binary found'"

--- a/docs/adr/0001-sqlite-vector.md
+++ b/docs/adr/0001-sqlite-vector.md
@@ -1,0 +1,32 @@
+# ADR 0001: Embedded SQLite with Vector Extensions
+
+**Status:** Accepted  
+**Date:** 2026-05-03
+
+## Context
+
+Ivai needs persistent memory. Options evaluated:
+
+| Option | Pros | Cons |
+|---|---|---|
+| PostgreSQL + pgvector | Full-featured | Requires separate process, adds complexity |
+| chromem-go (in-memory) | Pure Go, no deps | Not persistent, OOM risk |
+| SQLite + manual cosine | Embedded, zero-deps, persistent | No native vector index, brute-force search |
+| SQLite + sqlite-vec | Native vector index | Requires CGo, breaks pure-Go constraint |
+
+## Decision
+
+**SQLite with manual cosine similarity** stored as JSON BLOBs.
+
+## Rationale
+
+- Already using SQLite via `modernc.org/sqlite` (pure Go, no CGo)
+- Embedding count is small (<1000 initially) — brute-force cosine is fast enough
+- No new dependencies — embedding storage is just a new table
+- Migration path to sqlite-vec exists if scale demands it
+
+## Consequences
+
+- SearchSimilar loads all embeddings into memory (limit 200)
+- Cosine similarity threshold >0.3 filters noise
+- Embedding size: 1536 floats × 8 bytes = ~12KB per entry


### PR DESCRIPTION
## Summary

Architecture Decision Records, rollback capability, and safe deploy with `.prev` backup.

## Changes
- **ADR 0001**: SQLite + manual cosine similarity over sqlite-vec or chromem-go
- **make rollback**: restores `/usr/local/bin/ivai-os.prev`
- **Deploy safety**: `cp` current binary to `.prev` before overwriting

## Test Results
```
ok  github.com/IvanBern/ivai-os/cmd/ivai
ok  github.com/IvanBern/ivai-os/cmd/ivaictl
ok  github.com/IvanBern/ivai-os/internal/llm
ok  github.com/IvanBern/ivai-os/internal/memory
ok  github.com/IvanBern/ivai-os/internal/sandbox
ok  github.com/IvanBern/ivai-os/internal/telemetry
ok  github.com/IvanBern/ivai-os/internal/tools
```

## Code Health
```
CodeScene delta: No issues found! (10.0)
```

## Checklist
- [x] Tests pass
- [x] Code health 10.0
- [x] No secrets committed
