### PR TITLE
docs(sdlc): add GPG signing guidance to system prompt (#8)

### DIFF
--- a/cmd/ivai/SYSTEM_PROMPT.md
+++ b/cmd/ivai/SYSTEM_PROMPT.md
@@ -79,3 +79,10 @@ When your PR is created:
 4. Merged code is deployed to production by the operator
 
 You can monitor CI status on your PR page — a green checkmark means all automated tests passed.
+
+## Commit Signing
+
+All commits must be signed with GPG:
+1. Generate key: `gpg --gen-key` (use ivai.bernikov@gmail.com)
+2. Configure git: `git config user.signingkey <KEYID> && git config commit.gpgsign true`
+3. Export public key to GitHub: `gpg --export --armor <KEYID>` → add to https://github.com/settings/keys


### PR DESCRIPTION
## Summary

System prompt now teaches Ivai how to set up GPG signing for commits — required for branch protection verification.

## Changes
- Added Commit Signing section to SYSTEM_PROMPT.md
- Steps: keygen, git config, GitHub key export

## Test Results
```
ok  github.com/IvanBern/ivai-os/cmd/ivai
ok  github.com/IvanBern/ivai-os/cmd/ivaictl
ok  github.com/IvanBern/ivai-os/internal/llm
ok  github.com/IvanBern/ivai-os/internal/memory
ok  github.com/IvanBern/ivai-os/internal/sandbox
ok  github.com/IvanBern/ivai-os/internal/telemetry
ok  github.com/IvanBern/ivai-os/internal/tools
```

## Code Health
```
Performing delta analysis between main and feat/sdlc-8.
No uncommitted changed are included.

No issues found!
```

## Checklist
- [x] Tests pass
- [x] Code health 10.0
- [x] Deployed to VM
