### PR TITLE
fix: restore featureEnabled function and update tool count

### DIFF
--- a/cmd/ivai/main.go
+++ b/cmd/ivai/main.go
@@ -972,3 +972,6 @@ func shellQuote(s string) string {
 	q := fmt.Sprintf("%q", s)
 	return q
 }
+func featureEnabled(name string) bool {
+	return os.Getenv("IVAI_FEATURE_"+strings.ToUpper(name)) != "false"
+}

--- a/cmd/ivai/main_test.go
+++ b/cmd/ivai/main_test.go
@@ -517,7 +517,7 @@ func TestRegressionAllToolDispatch(t *testing.T) {
 	for _, tool := range tools {
 		toolNames[tool.Function.Name] = true
 	}
-	expected := []string{"read_file", "write_file", "execute_command", "execute_wasm", "http_request", "github_pr", "code_health", "create_issue", "list_issues"}
+	expected := []string{"read_file", "write_file", "execute_command", "execute_wasm", "http_request", "github_pr", "code_health", "create_issue", "list_issues", "update_wiki"}
 	for _, name := range expected {
 		if !toolNames[name] {
 			t.Errorf("tool %q not found in buildTools()", name)


### PR DESCRIPTION
## Summary\n\nRestores featureEnabled function lost during merge. Updates regression test for 10 tools.\n\n## Test Results\n```\nok  github.com/IvanBern/ivai-os/cmd/ivai\nok  github.com/IvanBern/ivai-os/cmd/ivaictl\nok  github.com/IvanBern/ivai-os/internal/llm\nok  github.com/IvanBern/ivai-os/internal/memory\nok  github.com/IvanBern/ivai-os/internal/sandbox\nok  github.com/IvanBern/ivai-os/internal/telemetry\nok  github.com/IvanBern/ivai-os/internal/tools\n```