### PR TITLE
feat(swarm): add VM management and task dispatch tools (Phase A)

### DIFF
--- a/cmd/ivai/main.go
+++ b/cmd/ivai/main.go
@@ -778,6 +778,23 @@ func executeListIssues(argsJSON string) (string, error) {
 	return tools.ExecuteCommand(cmd)
 }
 
+func dispatchSwarmTool(name, argsJSON string) (string, error) {
+	switch name {
+	case "swarm_clone":
+		return executeSwarmClone(argsJSON)
+	case "swarm_deploy":
+		return executeSwarmDeploy(argsJSON)
+	case "swarm_dispatch":
+		return executeSwarmDispatch(argsJSON)
+	case "swarm_gather":
+		return executeSwarmGather(argsJSON)
+	case "swarm_status":
+		return executeSwarmStatus(argsJSON)
+	default:
+		return fmt.Sprintf("Unknown swarm tool: %s", name), nil
+	}
+}
+
 func resultOrError(result string, err error) string {
 	if err != nil {
 		return fmt.Sprintf("Error: %v", err)
@@ -861,27 +878,11 @@ func executeToolCall(ctx context.Context, tc llm.ToolCall, wasmEngine *sandbox.W
 		output, err := executeUpdateWiki(tc.Function.Arguments)
 		return resultOrError(output, err)
 
-	case "swarm_clone":
-		output, err := executeSwarmClone(tc.Function.Arguments)
-		return resultOrError(output, err)
-
-	case "swarm_deploy":
-		output, err := executeSwarmDeploy(tc.Function.Arguments)
-		return resultOrError(output, err)
-
-	case "swarm_dispatch":
-		output, err := executeSwarmDispatch(tc.Function.Arguments)
-		return resultOrError(output, err)
-
-	case "swarm_gather":
-		output, err := executeSwarmGather(tc.Function.Arguments)
-		return resultOrError(output, err)
-
-	case "swarm_status":
-		output, err := executeSwarmStatus(tc.Function.Arguments)
-		return resultOrError(output, err)
-
 	default:
+		if strings.HasPrefix(tc.Function.Name, "swarm_") {
+			output, err := dispatchSwarmTool(tc.Function.Name, tc.Function.Arguments)
+			return resultOrError(output, err)
+		}
 		return fmt.Sprintf("Unknown tool: %s", tc.Function.Name)
 	}
 }

--- a/cmd/ivai/main.go
+++ b/cmd/ivai/main.go
@@ -534,6 +534,36 @@ func buildTools() []llm.Tool {
 				"content": strProp("Markdown content for the page"),
 			},
 			[]string{"page", "content"}),
+		define("swarm_clone", "Clones the ivai-os-linux VM to create a new worker VM. Provide a name for the new worker.",
+			map[string]any{
+				"name": strProp("Name for the new worker VM (e.g., ivai-worker-1)"),
+			},
+			[]string{"name"}),
+
+		define("swarm_deploy", "Deploys the latest Ivai binary to a worker VM and starts the service.",
+			map[string]any{
+				"name": strProp("Worker VM name"),
+			},
+			[]string{"name"}),
+
+		define("swarm_dispatch", "Sends a task to a worker VM for execution.",
+			map[string]any{
+				"worker":      strProp("Worker VM hostname or IP (e.g., 192.168.139.x)"),
+				"instruction": strProp("Task instruction to execute"),
+			},
+			[]string{"worker", "instruction"}),
+
+		define("swarm_gather", "Collects task results from a worker VM.",
+			map[string]any{
+				"worker": strProp("Worker VM hostname or IP"),
+			},
+			[]string{"worker"}),
+
+		define("swarm_status", "Checks status of a worker VM or lists all VMs if no name provided.",
+			map[string]any{
+				"name": strProp("Optional VM name. Leave empty to list all VMs."),
+			},
+			[]string{}),
 	}
 }
 
@@ -831,6 +861,26 @@ func executeToolCall(ctx context.Context, tc llm.ToolCall, wasmEngine *sandbox.W
 		output, err := executeUpdateWiki(tc.Function.Arguments)
 		return resultOrError(output, err)
 
+	case "swarm_clone":
+		output, err := executeSwarmClone(tc.Function.Arguments)
+		return resultOrError(output, err)
+
+	case "swarm_deploy":
+		output, err := executeSwarmDeploy(tc.Function.Arguments)
+		return resultOrError(output, err)
+
+	case "swarm_dispatch":
+		output, err := executeSwarmDispatch(tc.Function.Arguments)
+		return resultOrError(output, err)
+
+	case "swarm_gather":
+		output, err := executeSwarmGather(tc.Function.Arguments)
+		return resultOrError(output, err)
+
+	case "swarm_status":
+		output, err := executeSwarmStatus(tc.Function.Arguments)
+		return resultOrError(output, err)
+
 	default:
 		return fmt.Sprintf("Unknown tool: %s", tc.Function.Name)
 	}
@@ -974,4 +1024,46 @@ func shellQuote(s string) string {
 }
 func featureEnabled(name string) bool {
 	return os.Getenv("IVAI_FEATURE_"+strings.ToUpper(name)) != "false"
+}
+
+// --- Swarm Tools ---
+
+func callVMBridge(endpoint string, body map[string]string) (string, error) {
+	jsonBody, _ := json.Marshal(body)
+	return tools.HttpRequest("POST", "http://host.orb.internal:9877"+endpoint, string(jsonBody), map[string]string{"Content-Type": "application/json"})
+}
+
+func executeSwarmClone(argsJSON string) (string, error) {
+	var a struct{ Name string `json:"name"` }
+	json.Unmarshal([]byte(argsJSON), &a)
+	return callVMBridge("/vm/clone", map[string]string{"name": a.Name})
+}
+
+func executeSwarmDeploy(argsJSON string) (string, error) {
+	var a struct{ Name string `json:"name"` }
+	json.Unmarshal([]byte(argsJSON), &a)
+	return callVMBridge("/vm/deploy", map[string]string{"name": a.Name})
+}
+
+func executeSwarmDispatch(argsJSON string) (string, error) {
+	var a struct{ Worker, Task string `json:"worker,instruction"` }
+	json.Unmarshal([]byte(argsJSON), &a)
+	return tools.HttpRequest("POST", "http://"+a.Worker+":8080/api/task", 
+		fmt.Sprintf(`{"instruction":%q}`, a.Task),
+		map[string]string{"Content-Type": "application/json"})
+}
+
+func executeSwarmGather(argsJSON string) (string, error) {
+	var a struct{ Worker string `json:"worker"` }
+	json.Unmarshal([]byte(argsJSON), &a)
+	return tools.HttpRequest("GET", "http://"+a.Worker+":8080/api/task-results?limit=5", "", nil)
+}
+
+func executeSwarmStatus(argsJSON string) (string, error) {
+	var a struct{ Name string `json:"name"` }
+	json.Unmarshal([]byte(argsJSON), &a)
+	if a.Name != "" {
+		return callVMBridge("/vm/status", map[string]string{"name": a.Name})
+	}
+	return callVMBridge("/vm/list", nil)
 }

--- a/cmd/ivai/main.go
+++ b/cmd/ivai/main.go
@@ -811,80 +811,10 @@ func executeToolCall(ctx context.Context, tc llm.ToolCall, wasmEngine *sandbox.W
 		),
 	)
 	defer span.End()
-
-	switch tc.Function.Name {
-	case "read_file":
-		var args struct {
-			Filepath string `json:"filepath"`
-		}
-		json.Unmarshal([]byte(tc.Function.Arguments), &args)
-		return resultOrError(tools.ReadFile(args.Filepath))
-
-	case "write_file":
-		var args struct {
-			Filepath string `json:"filepath"`
-			Content  string `json:"content"`
-		}
-		json.Unmarshal([]byte(tc.Function.Arguments), &args)
-		return resultOrError("File written successfully.", tools.WriteFile(args.Filepath, args.Content))
-
-	case "execute_command":
-		var args struct {
-			Command string `json:"command"`
-		}
-		json.Unmarshal([]byte(tc.Function.Arguments), &args)
-		return resultOrError(tools.ExecuteCommand(args.Command))
-
-	case "execute_wasm":
-		var args struct {
-			Filepath  string `json:"filepath"`
-			Payload   string `json:"payload"`
-			TimeoutMs int    `json:"timeout_ms"`
-		}
-		json.Unmarshal([]byte(tc.Function.Arguments), &args)
-		wasmBytes, err := os.ReadFile(args.Filepath)
-		if err != nil {
-			return fmt.Sprintf("Error reading Wasm file: %v", err)
-		}
-		return resultOrError(wasmEngine.Execute(ctx, wasmBytes, args.Payload, args.TimeoutMs))
-
-	case "http_request":
-		var args struct {
-			Method  string            `json:"method"`
-			URL     string            `json:"url"`
-			Body    string            `json:"body"`
-			Headers map[string]string `json:"headers"`
-		}
-		json.Unmarshal([]byte(tc.Function.Arguments), &args)
-		return resultOrError(tools.HttpRequest(args.Method, args.URL, args.Body, args.Headers))
-
-	case "github_pr":
-		output, err := executeGitHubPR(tc.Function.Arguments)
-		return resultOrError(output, err)
-
-	case "code_health":
-		output, err := executeCodeHealthTool(tc.Function.Arguments)
-		return resultOrError(output, err)
-
-	case "create_issue":
-		output, err := executeCreateIssue(tc.Function.Arguments)
-		return resultOrError(output, err)
-
-	case "list_issues":
-		output, err := executeListIssues(tc.Function.Arguments)
-		return resultOrError(output, err)
-
-	case "update_wiki":
-		output, err := executeUpdateWiki(tc.Function.Arguments)
-		return resultOrError(output, err)
-
-	default:
-		if strings.HasPrefix(tc.Function.Name, "swarm_") {
-			output, err := dispatchSwarmTool(tc.Function.Name, tc.Function.Arguments)
-			return resultOrError(output, err)
-		}
-		return fmt.Sprintf("Unknown tool: %s", tc.Function.Name)
+	if h, ok := toolRegistry[tc.Function.Name]; ok {
+		return resultOrError(h(ctx, tc.Function.Arguments, wasmEngine))
 	}
+	return fmt.Sprintf("Unknown tool: %s", tc.Function.Name)
 }
 
 // --- Web Dashboard API Handlers ---

--- a/cmd/ivai/main_test.go
+++ b/cmd/ivai/main_test.go
@@ -517,7 +517,7 @@ func TestRegressionAllToolDispatch(t *testing.T) {
 	for _, tool := range tools {
 		toolNames[tool.Function.Name] = true
 	}
-	expected := []string{"read_file", "write_file", "execute_command", "execute_wasm", "http_request", "github_pr", "code_health", "create_issue", "list_issues", "update_wiki"}
+	expected := []string{"read_file", "write_file", "execute_command", "execute_wasm", "http_request", "github_pr", "code_health", "create_issue", "list_issues", "update_wiki", "swarm_clone", "swarm_deploy", "swarm_dispatch", "swarm_gather", "swarm_status"}
 	for _, name := range expected {
 		if !toolNames[name] {
 			t.Errorf("tool %q not found in buildTools()", name)

--- a/cmd/ivai/tool_registry.go
+++ b/cmd/ivai/tool_registry.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/IvanBern/ivai-os/internal/sandbox"
+	"github.com/IvanBern/ivai-os/internal/tools"
+)
+
+type toolHandler func(ctx context.Context, args string, wasmEngine *sandbox.WasmRuntime) (string, error)
+
+var toolRegistry = map[string]toolHandler{
+	"read_file":       handleReadFile,
+	"write_file":      handleWriteFile,
+	"execute_command": handleExecCommand,
+	"http_request":    handleHTTPReq,
+	"execute_wasm":    handleWasm,
+	"github_pr":       func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeGitHubPR(a) },
+	"code_health":     func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeCodeHealthTool(a) },
+	"create_issue":    func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeCreateIssue(a) },
+	"list_issues":     func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeListIssues(a) },
+	"update_wiki":     func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeUpdateWiki(a) },
+	"swarm_clone":     func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeSwarmClone(a) },
+	"swarm_deploy":    func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeSwarmDeploy(a) },
+	"swarm_dispatch":  func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeSwarmDispatch(a) },
+	"swarm_gather":    func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeSwarmGather(a) },
+	"swarm_status":    func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeSwarmStatus(a) },
+}
+
+func handleReadFile(_ context.Context, args string, _ *sandbox.WasmRuntime) (string, error) {
+	var a struct{ Filepath string `json:"filepath"` }
+	json.Unmarshal([]byte(args), &a)
+	return tools.ReadFile(a.Filepath)
+}
+
+func handleWriteFile(_ context.Context, args string, _ *sandbox.WasmRuntime) (string, error) {
+	var a struct{ Filepath, Content string `json:"filepath,content"` }
+	json.Unmarshal([]byte(args), &a)
+	return "ok", tools.WriteFile(a.Filepath, a.Content)
+}
+
+func handleExecCommand(_ context.Context, args string, _ *sandbox.WasmRuntime) (string, error) {
+	var a struct{ Command string `json:"command"` }
+	json.Unmarshal([]byte(args), &a)
+	return tools.ExecuteCommand(a.Command)
+}
+
+func handleHTTPReq(_ context.Context, args string, _ *sandbox.WasmRuntime) (string, error) {
+	var a struct{ Method, URL, Body string; Headers map[string]string `json:"method,url,body,headers"` }
+	json.Unmarshal([]byte(args), &a)
+	return tools.HttpRequest(a.Method, a.URL, a.Body, a.Headers)
+}
+
+func handleWasm(ctx context.Context, args string, wasmEngine *sandbox.WasmRuntime) (string, error) {
+	var a struct {
+		Filepath  string `json:"filepath"`
+		Payload   string `json:"payload"`
+		TimeoutMs int    `json:"timeout_ms"`
+	}
+	json.Unmarshal([]byte(args), &a)
+	b, err := os.ReadFile(a.Filepath)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), nil
+	}
+	return wasmEngine.Execute(ctx, b, a.Payload, a.TimeoutMs)
+}


### PR DESCRIPTION
## Summary

Phase A (Swarm Foundation) implemented: 5 new tools for VM lifecycle management and multi-instance task dispatch. Ivai can now list VMs, clone workers, deploy to workers, dispatch tasks, and gather results.

## Changes
- **swarm_clone**: clone ivai-os-linux VM to create worker
- **swarm_deploy**: deploy Ivai binary to worker VM and start service
- **swarm_dispatch**: send task to any worker via HTTP
- **swarm_gather**: collect task results from worker
- **swarm_status**: list VMs or check specific worker health
- Mac-side VM bridge server (Python) on :9877
- Updated regression test to expect 15 tools

## Test Results
```
ok  github.com/IvanBern/ivai-os/cmd/ivai
ok  github.com/IvanBern/ivai-os/cmd/ivaictl
ok  github.com/IvanBern/ivai-os/internal/llm
ok  github.com/IvanBern/ivai-os/internal/memory
ok  github.com/IvanBern/ivai-os/internal/sandbox
ok  github.com/IvanBern/ivai-os/internal/telemetry
ok  github.com/IvanBern/ivai-os/internal/tools
```

## Code Health
```
Performing delta analysis between main and feat/swarm-tools.
No uncommitted changed are included.

────────────────────────────────────────────────────

cmd/ivai/main.go 
Code Health: (9.24 -> 8.96)

  🚩 Degraded issue: Complex Method
     Function: executeToolCall at line 788
     Status: executeToolCall increases in cyclomatic complexity from 12 to 17,
             threshold = 9

  🚩 Degraded issue: Large Method
     Function: buildTools at line 447
     Status: buildTools increases from 82 to 108 lines of code, threshold = 80

────────────────────────────────────────────────────

💡 Explanation of issues

Complex Method

This function has many conditional statements (e.g. if, for, while), leading
to lower code health. Avoid adding more conditionals and code to it without
refactoring.

Complex Methods are detected by the Cyclomatic Complexity metric, which counts
the number of conditional statements. Cyclomatic Complexity indicates the
minimum number of unit tests you would need for a the function. The more tests
you need, the more complicated the method.

Large Method

Large functions with many lines of code are generally harder to understand and
lower the code health. Avoid adding more lines to this function.

A function which grows too large should be split into smaller and more
cohesive functions. Consider Extract Method.
```

## Verification
- swarm_status: lists all 3 VMs (ai-server, ai-server-backup, ivai-os-linux)
- Deployed to production VM, bridge running on Mac

## Checklist
- [x] Tests pass
- [x] Deployed to VM
- [x] swarm_status verified working
