### PR TITLE
fix(swarm): register spawn/kill tools in toolRegistry

### DIFF
--- a/cmd/ivai/tool_registry.go
+++ b/cmd/ivai/tool_registry.go
@@ -28,6 +28,8 @@ var toolRegistry = map[string]toolHandler{
 	"swarm_dispatch":  func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeSwarmDispatch(a) },
 	"swarm_gather":    func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeSwarmGather(a) },
 	"swarm_status":    func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeSwarmStatus(a) },
+	"swarm_spawn":     func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeSwarmSpawn(a) },
+	"swarm_kill":      func(_ context.Context, a string, _ *sandbox.WasmRuntime) (string, error) { return executeSwarmKill(a) },
 }
 
 func handleReadFile(_ context.Context, args string, _ *sandbox.WasmRuntime) (string, error) {


### PR DESCRIPTION
## Summary

spawn and kill were defined in buildTools but missing from toolRegistry — caused "Unknown tool" errors when Ivai tried to use them.

## Changes
- Added swarm_spawn and swarm_kill to toolRegistry map

## Test Results
```
ok  github.com/IvanBern/ivai-os/cmd/ivai
```

## Code Health
```
Performing delta analysis between main and fix/registry-spawn-kill.
No uncommitted changed are included.

No issues found!
```

## Checklist
- [x] Tests pass
- [x] Registry now has all 17 tools
- [x] Deployed to VM
