### PR TITLE
fix(swarm): use setsid for reliable local worker process spawn

### DIFF
--- a/cmd/ivai/main.go
+++ b/cmd/ivai/main.go
@@ -1025,7 +1025,7 @@ func executeSwarmSpawn(argsJSON string) (string, error) {
 		a.Port = "8081"
 	}
 	dataDir := "/tmp/ivai-" + a.Name
-	cmd := fmt.Sprintf("mkdir -p %s && IVAI_DATA_DIR=%s IVAI_PORT=%s nohup /usr/local/bin/ivai-os > /tmp/ivai-%s.log 2>&1 & sleep 2 && curl -s http://localhost:%s/api/status", dataDir, dataDir, a.Port, a.Name, a.Port)
+	cmd := fmt.Sprintf("mkdir -p %s && cp /etc/ivai/.env %s/.env 2>/dev/null; IVAI_DATA_DIR=%s IVAI_PORT=%s setsid /usr/local/bin/ivai-os < /dev/null > /tmp/ivai-%s.log 2>&1 & sleep 3 && curl -s http://localhost:%s/api/status", dataDir, dataDir, dataDir, a.Port, a.Name, a.Port)
 	out, err := tools.ExecuteCommand(cmd)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary

Replaced nohup with setsid for local worker spawn — workers now survive shell exit. Added .env copy to worker data dir.

## Changes
- setsid detaches worker process from bash -c session
- .env copied to /tmp/ivai-<name>/.env for API keys

## Test Results
```
ok  github.com/IvanBern/ivai-os/cmd/ivai
```

## Code Health
```
Performing delta analysis between main and fix/swarm-spawn-setsid.
No uncommitted changed are included.

No issues found!
```

## Verification
- Worker spawned on :8085, task dispatched, result "Four" returned

## Checklist
- [x] Tests pass
- [x] Local spawn verified end-to-end
