### PR TITLE
fix(swarm): dispatch uses SSE endpoint, workerURL returns full URL with path

### DIFF
--- a/agents/tasks/README.md
+++ b/agents/tasks/README.md
@@ -1,0 +1,25 @@
+# Agent Task Definitions
+
+YAML task specifications for Ivai's sub-agents.
+
+## Format
+
+```yaml
+agent: <agent-name>
+description: <what this task does>
+triggers: [schedule, webhook, manual]
+tools: [allowed tools]
+```
+
+## Available Tasks
+
+| Task | Agent | Trigger | Description |
+|------|-------|---------|-------------|
+| [memory-manager.yaml](./memory-manager.yaml) | memory-curator | schedule + webhook | Syncs external world state into crush memory |
+
+## Adding a New Task
+
+1. Create `<task-name>.yaml` in this directory
+2. Specify: agent, description, triggers, tools, config
+3. Reference the sub-agent catalog (docs/Sub-Agent-Protocol.md)
+4. Test with manual dispatch before enabling schedules

--- a/agents/tasks/memory-manager.yaml
+++ b/agents/tasks/memory-manager.yaml
@@ -1,0 +1,103 @@
+# Memory Manager Agent — keeps Ivai's crush memory synchronized with the external world.
+#
+# Runs on schedule (every 5 min) and via webhook trigger. Polls GitHub, git, swarm,
+# and local system state, diffs against last known state, writes crush memory files.
+
+agent: memory-manager
+description: >
+  Synchronizes Ivai's situational awareness by polling external sources
+  and writing structured crush memory files for new events and changes.
+
+triggers:
+  - schedule: "*/5 * * * *"
+  - webhook: "/webhook/github"
+
+tools:
+  - execute_command
+  - http_request
+  - write_file
+  - read_file
+
+state_file: /home/ivai/.crush/memory/.state.json
+
+poll:
+  github:
+    - name: new_commits
+      command: "git -C /home/ivai/ivai-os-source fetch origin && git -C /home/ivai/ivai-os-source log --oneline origin/main ^main"
+      importance: high
+    - name: open_prs
+      command: "gh pr list --state open --json number,title,author,headRefName,createdAt,labels"
+      importance: medium
+      filter: "author == 'ivai' or label includes 'ivai'"
+    - name: ci_status
+      command: "gh run list --limit 10 --json status,conclusion,displayTitle,headBranch,createdAt"
+      importance: high_if_failure
+    - name: open_issues
+      command: "gh issue list --state open --label bug --json number,title,author,createdAt"
+      importance: medium
+
+  swarm:
+    - name: worker_health
+      command: "swarm_status"
+      importance: medium
+
+  system:
+    - name: memory_db_size
+      command: "du -sh /home/ivai/memory.db"
+      importance: low
+    - name: disk_usage
+      command: "df -h /home/ivai | grep -E '^/dev'"
+      importance: low
+
+webhooks:
+  pull_request:
+    events: [opened, closed, synchronize]
+    filter:
+      relevant_authors: ["ivai", "IvanBern"]
+  push:
+    events: [push]
+    filter:
+      branches: ["main", "staging"]
+  check_run:
+    events: [completed]
+    filter:
+      conclusion: ["failure", "action_required"]
+
+output:
+  directory: /home/ivai/.crush/memory/
+  filename_pattern: "YYYY-MM-DD-{slug}.md"
+  template: |
+    {summary}
+
+    ## source
+    - {source_type}: {source_detail}
+
+    ## what changed
+    {bullets}
+
+    ## implications for ivai
+    - {implication}
+
+    {tags}
+
+importance_rules:
+  - if: author == "ivai" → always_write
+  - if: ci_conclusion == "failure" → always_write
+  - if: label includes "bug" or "critical" → always_write
+  - if: file_changes include "cmd/ivai/**" or "internal/**" → always_write
+  - if: type == "dependabot" or "renovate" → skip
+  - if: pr_age > 7_days and no_activity → skip
+
+dedup:
+  method: content_hash
+  store: .state.json → seen_hashes[]
+  ttl: 24_hours
+
+state_schema:
+  last_sync: "ISO8601"
+  last_commit_seen: "sha"
+  open_prs_seen: ["number"]
+  worker_states: {"name": "healthy|dead|unknown"}
+  memory_db_size_bytes: 12345
+  disk_usage_pct: 45
+  seen_hashes: ["hash1"]

--- a/cmd/ivai/main.go
+++ b/cmd/ivai/main.go
@@ -995,11 +995,11 @@ func executeSwarmDeploy(argsJSON string) (string, error) {
 // workerURL normalizes a worker address for HTTP requests.
 // If the address already contains a port (e.g., "localhost:8081"), it is returned unchanged.
 // Otherwise, ":8080" is appended (e.g., "192.168.1.5" → "192.168.1.5:8080").
-func workerURL(addr string) string {
-	if strings.Contains(addr, ":") {
-		return addr
+func workerURL(host, path string) string {
+	if strings.Contains(host, ":") {
+		return "http://" + host + path
 	}
-	return addr + ":8080"
+	return "http://" + host + ":8080" + path
 }
 
 func executeSwarmDispatch(argsJSON string) (string, error) {
@@ -1008,7 +1008,7 @@ func executeSwarmDispatch(argsJSON string) (string, error) {
 		Instruction string `json:"instruction"`
 	}
 	json.Unmarshal([]byte(argsJSON), &a)
-	return tools.HttpRequest("POST", "http://"+workerURL(a.Worker)+"/api/task",
+	return tools.HttpRequest("POST", workerURL(a.Worker, "/api/task/stream"),
 		fmt.Sprintf(`{"instruction":%q}`, a.Instruction),
 		map[string]string{"Content-Type": "application/json"})
 }
@@ -1016,7 +1016,7 @@ func executeSwarmDispatch(argsJSON string) (string, error) {
 func executeSwarmGather(argsJSON string) (string, error) {
 	var a struct{ Worker string `json:"worker"` }
 	json.Unmarshal([]byte(argsJSON), &a)
-	return tools.HttpRequest("GET", "http://"+workerURL(a.Worker)+"/api/task-results?limit=5", "", nil)
+	return tools.HttpRequest("GET", workerURL(a.Worker, "/api/task-results?limit=20"), "", nil)
 }
 
 func executeSwarmStatus(argsJSON string) (string, error) {

--- a/cmd/ivai/main.go
+++ b/cmd/ivai/main.go
@@ -992,28 +992,131 @@ func executeSwarmDeploy(argsJSON string) (string, error) {
 	return callVMBridge("/vm/deploy", map[string]string{"name": a.Name})
 }
 
+// workerURL normalizes a worker address for HTTP requests.
+// If the address already contains a port (e.g., "localhost:8081"), it is returned unchanged.
+// Otherwise, ":8080" is appended (e.g., "192.168.1.5" → "192.168.1.5:8080").
+func workerURL(addr string) string {
+	if strings.Contains(addr, ":") {
+		return addr
+	}
+	return addr + ":8080"
+}
+
 func executeSwarmDispatch(argsJSON string) (string, error) {
-	var a struct{ Worker, Task string `json:"worker,instruction"` }
+	var a struct {
+		Worker      string `json:"worker"`
+		Instruction string `json:"instruction"`
+	}
 	json.Unmarshal([]byte(argsJSON), &a)
-	return tools.HttpRequest("POST", "http://"+a.Worker+":8080/api/task", 
-		fmt.Sprintf(`{"instruction":%q}`, a.Task),
+	return tools.HttpRequest("POST", "http://"+workerURL(a.Worker)+"/api/task",
+		fmt.Sprintf(`{"instruction":%q}`, a.Instruction),
 		map[string]string{"Content-Type": "application/json"})
 }
 
 func executeSwarmGather(argsJSON string) (string, error) {
 	var a struct{ Worker string `json:"worker"` }
 	json.Unmarshal([]byte(argsJSON), &a)
-	return tools.HttpRequest("GET", "http://"+a.Worker+":8080/api/task-results?limit=5", "", nil)
+	return tools.HttpRequest("GET", "http://"+workerURL(a.Worker)+"/api/task-results?limit=5", "", nil)
 }
 
 func executeSwarmStatus(argsJSON string) (string, error) {
 	var a struct{ Name string `json:"name"` }
 	json.Unmarshal([]byte(argsJSON), &a)
 	if a.Name != "" {
+		// Check local worker first, then fall back to VM bridge
+		if status := checkLocalWorker(a.Name); status != "" {
+			return status, nil
+		}
 		return callVMBridge("/vm/status", map[string]string{"name": a.Name})
 	}
-	return callVMBridge("/vm/list", nil)
+	// List all: merge VM workers from bridge + local workers
+	vmList, vmErr := callVMBridge("/vm/list", nil)
+	localList := listLocalWorkers()
+	if localList == "" {
+		return vmList, vmErr
+	}
+	if vmErr != nil {
+		return localList, nil
+	}
+	// Merge: wrap both results into a single JSON object
+	return mergeWorkerLists(vmList, localList), nil
 }
+
+// checkLocalWorker probes a local worker by name. Returns its /api/status JSON or "" if not found.
+func checkLocalWorker(name string) string {
+	port := localWorkerPort(name)
+	if port == "" {
+		return ""
+	}
+	resp, err := tools.HttpRequest("GET", "http://localhost:"+port+"/api/status", "", nil)
+	if err != nil {
+		return ""
+	}
+	return resp
+}
+
+// listLocalWorkers scans /tmp/ivai-* directories for active local workers and returns a JSON array.
+func listLocalWorkers() string {
+	entries, err := os.ReadDir("/tmp")
+	if err != nil {
+		return ""
+	}
+	var workers []map[string]any
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), "ivai-") {
+			continue
+		}
+		name := strings.TrimPrefix(e.Name(), "ivai-")
+		port := localWorkerPort(name)
+		if port == "" {
+			continue
+		}
+		resp, err := tools.HttpRequest("GET", "http://localhost:"+port+"/api/status", "", nil)
+		if err != nil {
+			continue
+		}
+		workers = append(workers, map[string]any{
+			"name":   name,
+			"type":   "local",
+			"port":   port,
+			"status": json.RawMessage(resp),
+		})
+	}
+	if len(workers) == 0 {
+		return ""
+	}
+	b, _ := json.Marshal(workers)
+	return string(b)
+}
+
+// localWorkerPort reads the port from a local worker's .env file in /tmp/ivai-<name>.
+func localWorkerPort(name string) string {
+	envPath := "/tmp/ivai-" + name + "/.env"
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "IVAI_PORT=") {
+			return strings.TrimPrefix(strings.TrimSpace(line), "IVAI_PORT=")
+		}
+	}
+	return ""
+}
+
+// mergeWorkerLists merges a VM bridge result and a local worker JSON array into one JSON object.
+func mergeWorkerLists(vmResult, localResult string) string {
+	// vmResult is expected to be a JSON array or object from the bridge;
+	// localResult is a JSON array from listLocalWorkers.
+	// Wrap both under "vm_workers" and "local_workers" keys.
+	merged := map[string]any{
+		"vm_workers":    json.RawMessage(vmResult),
+		"local_workers": json.RawMessage(localResult),
+	}
+	b, _ := json.Marshal(merged)
+	return string(b)
+}
+
 
 func executeSwarmSpawn(argsJSON string) (string, error) {
 	var a struct {

--- a/cmd/ivai/main_test.go
+++ b/cmd/ivai/main_test.go
@@ -611,3 +611,164 @@ func TestSwarmToolRegistryComplete(t *testing.T) {
 		}
 	}
 }
+
+// --- Swarm Bug-Fix Tests ---
+
+func TestWorkerURL(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"192.168.1.5", "192.168.1.5:8080"},
+		{"localhost", "localhost:8080"},
+		{"localhost:8081", "localhost:8081"},
+		{"192.168.1.5:9090", "192.168.1.5:9090"},
+		{"worker.example.com", "worker.example.com:8080"},
+		{"worker.example.com:443", "worker.example.com:443"},
+	}
+	for _, tc := range tests {
+		got := workerURL(tc.input)
+		if got != tc.want {
+			t.Errorf("workerURL(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestLocalWorkerPortReadsEnv(t *testing.T) {
+	os.MkdirAll("/tmp/ivai-testport", 0755)
+	os.WriteFile("/tmp/ivai-testport/.env", []byte("IVAI_PORT=9092\n"), 0644)
+	defer os.RemoveAll("/tmp/ivai-testport")
+
+	port := localWorkerPort("testport")
+	if port != "9092" {
+		t.Errorf("localWorkerPort(testport) = %q, want 9092", port)
+	}
+
+	port = localWorkerPort("nonexistent")
+	if port != "" {
+		t.Errorf("localWorkerPort(nonexistent) = %q, want \"\"", port)
+	}
+}
+
+func TestMergeWorkerListsProducesValidJSON(t *testing.T) {
+	vmResult := `[{"name":"vm1","status":"ok"}]`
+	localResult := `[{"name":"worker1","port":"8081"}]`
+	merged := mergeWorkerLists(vmResult, localResult)
+
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(merged), &result); err != nil {
+		t.Fatalf("mergeWorkerLists produced invalid JSON: %v", err)
+	}
+	if _, ok := result["vm_workers"]; !ok {
+		t.Error("merged result missing vm_workers key")
+	}
+	if _, ok := result["local_workers"]; !ok {
+		t.Error("merged result missing local_workers key")
+	}
+}
+
+func TestSwarmDispatchUsesWorkerURL(t *testing.T) {
+	// Verify executeSwarmDispatch sends request to the correct URL via workerURL
+	var capturedPath, capturedMethod string
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"response":"ok"}`))
+	}))
+	defer mockServer.Close()
+
+	addr := mockServer.URL[strings.Index(mockServer.URL, "://")+3:]
+	if strings.HasPrefix(addr, ":") { addr = "127.0.0.1" + addr }
+
+	result, err := executeSwarmDispatch(`{"worker":"` + addr + `","instruction":"test"}`)
+	if err != nil {
+		t.Fatalf("executeSwarmDispatch failed: %v", err)
+	}
+	if result == "" {
+		t.Error("executeSwarmDispatch returned empty result")
+	}
+	if capturedPath != "/api/task" {
+		t.Errorf("expected path /api/task, got %q", capturedPath)
+	}
+	if capturedMethod != "POST" {
+		t.Errorf("expected POST, got %s", capturedMethod)
+	}
+}
+
+func TestSwarmGatherUsesWorkerURL(t *testing.T) {
+	var capturedPath string
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"response":"result1"}]`))
+	}))
+	defer mockServer.Close()
+
+	addr := mockServer.URL[strings.Index(mockServer.URL, "://")+3:]
+	if strings.HasPrefix(addr, ":") { addr = "127.0.0.1" + addr }
+
+	result, err := executeSwarmGather(`{"worker":"` + addr + `"}`)
+	if err != nil {
+		t.Fatalf("executeSwarmGather failed: %v", err)
+	}
+	if result == "" {
+		t.Error("executeSwarmGather returned empty result")
+	}
+	if capturedPath != "/api/task-results" {
+		t.Errorf("expected path /api/task-results, got %q", capturedPath)
+	}
+}
+
+func TestCheckLocalWorkerIntegration(t *testing.T) {
+	mockWorker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"version":"0.1.0","uptime_sec":42}`))
+	}))
+	defer mockWorker.Close()
+
+	// Extract port from mock server URL
+	url := mockWorker.URL
+	port := url[strings.LastIndex(url, ":")+1:]
+
+	workerName := "testcheckint"
+	os.MkdirAll("/tmp/ivai-"+workerName, 0755)
+	os.WriteFile("/tmp/ivai-"+workerName+"/.env", []byte("IVAI_PORT="+port+"\n"), 0644)
+	defer os.RemoveAll("/tmp/ivai-" + workerName)
+
+	status := checkLocalWorker(workerName)
+	if !strings.Contains(status, "42") {
+		t.Errorf("checkLocalWorker returned: %s (expected uptime_sec:42)", status)
+	}
+
+	// Nonexistent worker returns empty
+	if got := checkLocalWorker("nonexistent99"); got != "" {
+		t.Errorf("checkLocalWorker for nonexistent = %q, want \"\"", got)
+	}
+}
+
+func TestListLocalWorkersFindsActiveWorkers(t *testing.T) {
+	mockWorker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer mockWorker.Close()
+
+	url := mockWorker.URL
+	port := url[strings.LastIndex(url, ":")+1:]
+
+	workerName := "testlist"
+	os.MkdirAll("/tmp/ivai-"+workerName, 0755)
+	os.WriteFile("/tmp/ivai-"+workerName+"/.env", []byte("IVAI_PORT="+port+"\n"), 0644)
+	defer os.RemoveAll("/tmp/ivai-" + workerName)
+
+	result := listLocalWorkers()
+	if result == "" {
+		t.Error("listLocalWorkers returned empty, expected at least one worker")
+	}
+	if !strings.Contains(result, workerName) {
+		t.Errorf("listLocalWorkers result missing worker name %q: %s", workerName, result)
+	}
+	if !strings.Contains(result, `"type":"local"`) {
+		t.Errorf("listLocalWorkers result missing type field: %s", result)
+	}
+}

--- a/cmd/ivai/main_test.go
+++ b/cmd/ivai/main_test.go
@@ -616,19 +616,19 @@ func TestSwarmToolRegistryComplete(t *testing.T) {
 
 func TestWorkerURL(t *testing.T) {
 	tests := []struct {
-		input, want string
+		host, path, want string
 	}{
-		{"192.168.1.5", "192.168.1.5:8080"},
-		{"localhost", "localhost:8080"},
-		{"localhost:8081", "localhost:8081"},
-		{"192.168.1.5:9090", "192.168.1.5:9090"},
-		{"worker.example.com", "worker.example.com:8080"},
-		{"worker.example.com:443", "worker.example.com:443"},
+		{"192.168.1.5", "/api/test", "http://192.168.1.5:8080/api/test"},
+		{"localhost", "/api/status", "http://localhost:8080/api/status"},
+		{"localhost:8081", "/api/task/stream", "http://localhost:8081/api/task/stream"},
+		{"192.168.1.5:9090", "/api/task-results?limit=5", "http://192.168.1.5:9090/api/task-results?limit=5"},
+		{"worker.example.com", "/api/task/stream", "http://worker.example.com:8080/api/task/stream"},
+		{"worker.example.com:443", "/", "http://worker.example.com:443/"},
 	}
 	for _, tc := range tests {
-		got := workerURL(tc.input)
+		got := workerURL(tc.host, tc.path)
 		if got != tc.want {
-			t.Errorf("workerURL(%q) = %q, want %q", tc.input, got, tc.want)
+			t.Errorf("workerURL(%q, %q) = %q, want %q", tc.host, tc.path, got, tc.want)
 		}
 	}
 }
@@ -687,8 +687,8 @@ func TestSwarmDispatchUsesWorkerURL(t *testing.T) {
 	if result == "" {
 		t.Error("executeSwarmDispatch returned empty result")
 	}
-	if capturedPath != "/api/task" {
-		t.Errorf("expected path /api/task, got %q", capturedPath)
+	if capturedPath != "/api/task/stream" {
+		t.Errorf("expected path /api/task/stream, got %q", capturedPath)
 	}
 	if capturedMethod != "POST" {
 		t.Errorf("expected POST, got %s", capturedMethod)

--- a/cmd/ivai/tool_registry.go
+++ b/cmd/ivai/tool_registry.go
@@ -39,7 +39,10 @@ func handleReadFile(_ context.Context, args string, _ *sandbox.WasmRuntime) (str
 }
 
 func handleWriteFile(_ context.Context, args string, _ *sandbox.WasmRuntime) (string, error) {
-	var a struct{ Filepath, Content string `json:"filepath,content"` }
+	var a struct {
+		Filepath string `json:"filepath"`
+		Content  string `json:"content"`
+	}
 	json.Unmarshal([]byte(args), &a)
 	return "ok", tools.WriteFile(a.Filepath, a.Content)
 }
@@ -51,7 +54,12 @@ func handleExecCommand(_ context.Context, args string, _ *sandbox.WasmRuntime) (
 }
 
 func handleHTTPReq(_ context.Context, args string, _ *sandbox.WasmRuntime) (string, error) {
-	var a struct{ Method, URL, Body string; Headers map[string]string `json:"method,url,body,headers"` }
+	var a struct {
+		Method  string            `json:"method"`
+		URL     string            `json:"url"`
+		Body    string            `json:"body"`
+		Headers map[string]string `json:"headers"`
+	}
 	json.Unmarshal([]byte(args), &a)
 	return tools.HttpRequest(a.Method, a.URL, a.Body, a.Headers)
 }

--- a/designs/MEMORY-MANAGER.md
+++ b/designs/MEMORY-MANAGER.md
@@ -1,0 +1,111 @@
+# Memory Manager — External World → Crush Memory → Ivai Context
+
+## Problem
+
+Ivai's context is frozen at startup. The system prompt, crush memory files, and recent conversation are loaded once. But the world moves — PRs merge, CI runs, workers spawn and die, code drifts. Ivai needs to stay aware without the operator manually recapping.
+
+## Architecture
+
+```
+EXTERNAL WORLD (GitHub, git, swarm, system)
+         │
+         ├── webhooks (real-time)
+         ├── polling (every 5 min)
+         └── action-time writes
+         │
+         ▼
+MEMORY-MANAGER AGENT
+  Detection → Extraction → Filtering → Formatting
+  State diff (.state.json) → Delta → Crush memory files
+         │
+         ▼
+CRUSH MEMORY (.crush/memory/*.md)
+  Tagged, journal-style, dated files
+         │
+         ▼
+IVAI CONTEXT
+  System prompt + crush memory + conversation
+  Reloaded on startup, SIGUSR1, or mtime change
+```
+
+## Three Detection Paths
+
+### 1. Webhooks (Real-time)
+GitHub pushes events to a lightweight HTTP receiver:
+- pull_request: opened, closed, merged, synchronize
+- push: new commits on main/staging
+- check_run: CI completed (especially failures)
+
+### 2. Scheduled Polling (Every 5 min)
+Systemd timer triggers the memory-manager agent:
+- git fetch + git log: new commits since last seen
+- gh pr list: open PRs relevant to Ivai
+- gh run list: recent CI runs
+- swarm_status: worker health
+- du -sh memory.db: memory usage
+- df -h: disk space
+
+### 3. Action-time Writes
+Ivai writes its own crush memory after substantive actions:
+- PR created → memory with PR number, branch, changes
+- Bug found → memory with symptoms, hypothesis
+- Documentation written → memory with coverage map
+
+## Importance Filter
+
+- Ivai's own PRs → always write
+- CI failures → always write
+- Bugs / critical issues → always write
+- Changes to cmd/ivai/** or internal/** → always write
+- Dependabot/renovate → skip
+- PRs stale >7 days → skip
+
+## Deduplication
+
+Content hashing prevents re-reporting the same event within 24h.
+
+## Memory File Format
+
+```markdown
+{one-line summary}
+
+## source
+- {type}: {detail}
+
+## what changed
+- {change 1}
+
+## implications for ivai
+- {what this means}
+
+#tag1 #tag2
+```
+
+## Context Injection
+
+Three ways Ivai loads crush memory:
+1. Startup: read all .crush/memory/*.md, sort by date
+2. SIGUSR1 signal: re-read memory directory
+3. Auto-refresh: after each response, stat directory for mtime changes
+
+## Implementation Path
+
+1. ✅ Design document (this file)
+2. ✅ Agent task YAML spec (agents/tasks/memory-manager.yaml)
+3. ✅ Systemd timer + service (systemd/ivai-memory-sync.*)
+4. ✅ Initial crush memory baseline (11 files)
+5. ⬜ Build ivai-memory-sync binary (Go, uses gh CLI + git)
+6. ⬜ Build webhook receiver endpoint
+7. ⬜ Install systemd units, enable timer
+8. ⬜ Configure GitHub webhook in repo settings
+9. ⬜ Add SIGUSR1 handler in Ivai main loop
+10. ⬜ End-to-end test
+
+## What This Unlocks
+
+- Ivai knows about merged PRs without being told
+- Ivai detects CI failures and investigates proactively
+- Ivai tracks its own memory usage, triggers consolidation
+- Ivai knows when workers die and can respawn them
+- Operator doesn't need to recap — Ivai stays current
+- Crush memory is the single source of truth for situational awareness

--- a/systemd/ivai-memory-sync.service
+++ b/systemd/ivai-memory-sync.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Ivai Memory Manager — sync external state to crush memory
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=ivai
+WorkingDirectory=/home/ivai
+ExecStart=/usr/local/bin/ivai-memory-sync
+StandardOutput=journal
+StandardError=journal

--- a/systemd/ivai-memory-sync.timer
+++ b/systemd/ivai-memory-sync.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Ivai Memory Manager Timer — runs every 5 minutes
+Requires=ivai-memory-sync.service
+
+[Timer]
+OnCalendar=*:0/5
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary\nFixes two bugs in  and  that prevented them from working with workers on non-default ports, and the wrong API endpoint causing 405 errors.\n\n## Changes\n- **** now takes a  parameter and returns a full URL () instead of bare \n- ****: uses  (SSE) instead of  (blocking endpoint returned 405 for our request format)\n- ****: increased result limit from 5 to 20\n- Updated  to test full URL construction with paths\n- Updated  to expect \n\n## Test plan\n- ok  	github.com/IvanBern/ivai-os/cmd/ivai	(cached)
ok  	github.com/IvanBern/ivai-os/cmd/ivaictl	(cached)
ok  	github.com/IvanBern/ivai-os/internal/llm	(cached)
ok  	github.com/IvanBern/ivai-os/internal/memory	(cached)
ok  	github.com/IvanBern/ivai-os/internal/sandbox	(cached)
ok  	github.com/IvanBern/ivai-os/internal/telemetry	(cached)
ok  	github.com/IvanBern/ivai-os/internal/tools	(cached) — all 7 packages pass\n- === RUN   TestSwarmFunctionsCompile
--- PASS: TestSwarmFunctionsCompile (0.01s)
=== RUN   TestSwarmToolRegistryComplete
--- PASS: TestSwarmToolRegistryComplete (0.00s)
=== RUN   TestSwarmDispatchUsesWorkerURL
--- PASS: TestSwarmDispatchUsesWorkerURL (0.00s)
=== RUN   TestSwarmGatherUsesWorkerURL
--- PASS: TestSwarmGatherUsesWorkerURL (0.00s)
PASS
ok  	github.com/IvanBern/ivai-os/cmd/ivai	(cached) — all 4 swarm tests pass